### PR TITLE
feat: add real-time search filter for photo descriptions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -276,3 +276,47 @@ body {
         font-size: 1.2rem;
     }
 }
+
+/* Search Styles */
+.search-container {
+    width: 100%;
+    max-width: 500px;
+    margin: 0 auto 2rem;
+    padding: 0 2rem;
+}
+
+#search-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-family: var(--font-ui);
+    font-size: 1rem;
+    color: var(--text-color);
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    outline: none;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+#search-input::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+#search-input:focus {
+    border-color: rgba(255, 255, 255, 0.4);
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.no-results {
+    text-align: center;
+    color: rgba(255, 255, 255, 0.6);
+    padding: 4rem 2rem;
+    font-size: 1.1rem;
+}
+
+@media (max-width: 600px) {
+    .search-container {
+        padding: 0 1rem;
+        margin-bottom: 1.5rem;
+    }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,6 +5,8 @@ const CONFIG = {
 };
 
 const galleryContainer = document.getElementById('gallery');
+const searchInput = document.getElementById('search-input');
+let allImages = []; // Store all images for filtering
 
 async function init() {
     try {
@@ -20,7 +22,13 @@ async function init() {
         // Randomize order
         shuffleArray(images);
 
+        // Store for filtering
+        allImages = images;
+
         renderGallery(images);
+
+        // Setup search
+        setupSearch();
 
     } catch (error) {
         console.error('Error initializing gallery:', error);
@@ -186,6 +194,37 @@ function displayRandomQuote() {
         const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
         quoteElement.innerText = `"${randomQuote.text}"`;
         authorElement.innerText = `— ${randomQuote.author}`;
+    }
+}
+
+// Search/Filter Logic
+function setupSearch() {
+    let debounceTimer;
+    searchInput.addEventListener('input', (e) => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            filterGallery(e.target.value);
+        }, 300);
+    });
+}
+
+function filterGallery(searchTerm) {
+    const term = searchTerm.toLowerCase().trim();
+
+    if (!term) {
+        renderGallery(allImages);
+        return;
+    }
+
+    const filtered = allImages.filter(img =>
+        img.description && img.description.toLowerCase().includes(term)
+    );
+
+    if (filtered.length === 0) {
+        galleryContainer.innerHTML = '<p class="no-results">No photos match your search.</p>';
+        galleryImages = [];
+    } else {
+        renderGallery(filtered);
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
         </div>
     </header>
 
+    <div class="search-container">
+        <input type="text" id="search-input" placeholder="Search photos..." aria-label="Search photos by description">
+    </div>
+
     <div class="gallery" id="gallery">
         <!-- Images will be injected here -->
     </div>


### PR DESCRIPTION
## Summary
- Add search input below the quote header that filters gallery images in real-time
- Filter matches any part of description (case-insensitive)
- Debounce input for 300ms to prevent excessive re-renders
- Show "No photos match your search" message when filter returns empty
- Lightbox navigation cycles through filtered results only

## Test plan
- [ ] Type in search box and verify gallery filters in real-time
- [ ] Verify partial matches work (e.g., "Budapest" matches all Budapest photos)
- [ ] Verify case-insensitive matching
- [ ] Clear search and verify all photos return
- [ ] Open lightbox on filtered results and verify prev/next only cycles filtered images
- [ ] Test on mobile for responsive styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)