### PR TITLE
feat: add album sidebar for filtering photos by category

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -320,3 +320,96 @@ body {
         margin-bottom: 1.5rem;
     }
 }
+
+/* Page Layout */
+.page-layout {
+    display: flex;
+    gap: 2rem;
+    max-width: 1800px;
+    margin: 0 auto;
+}
+
+.sidebar {
+    width: 200px;
+    flex-shrink: 0;
+}
+
+.sidebar h2 {
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.5);
+    margin-bottom: 1rem;
+}
+
+.album-list {
+    list-style: none;
+}
+
+.album-item {
+    padding: 0.6rem 0.75rem;
+    margin-bottom: 0.25rem;
+    border-radius: 6px;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.95rem;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.album-item:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.album-item.active {
+    background-color: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    font-weight: 500;
+}
+
+.main-content {
+    flex: 1;
+    min-width: 0;
+}
+
+/* Adjust gallery max-width since it's now inside main-content */
+.main-content .gallery {
+    max-width: none;
+}
+
+.main-content .search-container {
+    max-width: none;
+    padding: 0;
+    margin-bottom: 1.5rem;
+}
+
+/* Mobile: Sidebar becomes horizontal pills */
+@media (max-width: 900px) {
+    .page-layout {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .sidebar {
+        width: 100%;
+    }
+
+    .sidebar h2 {
+        display: none;
+    }
+
+    .album-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .album-item {
+        padding: 0.5rem 1rem;
+        margin-bottom: 0;
+        background-color: rgba(255, 255, 255, 0.1);
+        font-size: 0.85rem;
+    }
+}

--- a/assets/images.json
+++ b/assets/images.json
@@ -1,130 +1,252 @@
 [
     {
         "filename": "PXL_20251020_224244082.RAW-01.jpg",
-        "description": "Airport Lounge Lights"
+        "description": "Airport Lounge Lights",
+        "albums": [
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251023_100743902.jpg",
-        "description": "View from Petrin Tower, Prague"
+        "description": "View from Petrin Tower, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251023_115105910.jpg",
-        "description": "Strahov Monastery Brewery, Prague"
+        "description": "Strahov Monastery Brewery, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251023_164030463.jpg",
-        "description": "Church of Our Lady of Tyn, Prague"
+        "description": "Church of Our Lady of Tyn, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251024_135645713.jpg",
-        "description": "Staircase at the House of the Black Madonna, Prague"
+        "description": "Staircase at the House of the Black Madonna, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251025_132918581 Copy Copy.jpg",
-        "description": "Cathedral of St. Barabara, Kutna Hora"
+        "description": "Cathedral of St. Barabara, Kutna Hora",
+        "albums": [
+            "Czech Republic",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251028_084220438~2.jpg",
-        "description": "Schloss Hellbrunn, Salzburg"
+        "description": "Schloss Hellbrunn, Salzburg",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251028_103351023.jpg",
-        "description": "Drachebnwand (Dragobnwall), Mondsee (Moon Lake), Austria"
+        "description": "Drachebnwand (Dragobnwall), Mondsee (Moon Lake), Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251028_111252630.jpg",
-        "description": "Hilfbergkirche (Pilgrimage Church), Mondsee (Moon Lake), Austria"
+        "description": "Hilfbergkirche (Pilgrimage Church), Mondsee (Moon Lake), Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251028_111630037.jpg",
-        "description": "Tennengebirge (Tann Mountain), Mondsee (Moon Lake), Austria"
+        "description": "Tennengebirge (Tann Mountain), Mondsee (Moon Lake), Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251028_112941865~2.jpg",
-        "description": "Tennengebirge (Tann Mountain), Mondsee (Moon Lake), Austria"
+        "description": "Tennengebirge (Tann Mountain), Mondsee (Moon Lake), Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251029_121407876.jpg",
-        "description": "Flower arrangement at the Vienna State Opera, Austria"
+        "description": "Flower arrangement at the Vienna State Opera, Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251031_131726202.jpg",
-        "description": "Path at Schönbrunn Palace, Austria"
+        "description": "Path at Schönbrunn Palace, Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251031_133522971 Copy.jpg",
-        "description": "Path at Schönbrunn Palace, Austria"
+        "description": "Path at Schönbrunn Palace, Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251031_133555276.jpg",
-        "description": "Path at Schönbrunn Palace, Austria"
+        "description": "Path at Schönbrunn Palace, Austria",
+        "albums": [
+            "Austria",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251102_083508044~2.jpg",
-        "description": "Sunday morning walk in Budapest"
+        "description": "Sunday morning walk in Budapest",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251102_105040583.PANO.jpg",
-        "description": "Matthias Church, Buda Castle, Budapest"
+        "description": "Matthias Church, Buda Castle, Budapest",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251102_163930809.jpg",
-        "description": "Széchenyl Chain Bridge, Budapest"
+        "description": "Széchenyl Chain Bridge, Budapest",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251103_185851176.jpg",
-        "description": "National Athletics Centre, Budapest"
+        "description": "National Athletics Centre, Budapest",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251103_192457486.jpg",
-        "description": "Liberty Bridge, Budapest"
+        "description": "Liberty Bridge, Budapest",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "PXL_20251112_014425893.NIGHT.jpg",
-        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025"
+        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025",
+        "albums": [
+            "Northern Lights"
+        ]
     },
     {
         "filename": "PXL_20251112_021910010.NIGHT.jpg",
-        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025"
+        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025",
+        "albums": [
+            "Northern Lights"
+        ]
     },
     {
         "filename": "PXL_20251112_022015235.NIGHT.jpg",
-        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025"
+        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025",
+        "albums": [
+            "Northern Lights"
+        ]
     },
     {
         "filename": "PXL_20251112_022213019.NIGHT.jpg",
-        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025"
+        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025",
+        "albums": [
+            "Northern Lights"
+        ]
     },
     {
         "filename": "PXL_20251112_022523067.NIGHT.jpg",
-        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025"
+        "description": "Northern Lights, Woodstock, IL - Nov 12, 2025",
+        "albums": [
+            "Northern Lights"
+        ]
     },
     {
         "filename": "original_1c40cc91-497c-41be-90f2-d6821dc33546_PXL_20251023_093315700~2.jpg",
-        "description": "The path up Petrin Tower, Prague"
+        "description": "The path up Petrin Tower, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "Budapest Parlament IMG_2161-topaz-sharpen.jpg",
-        "description": "Budapest Parliament Building"
+        "description": "Budapest Parliament Building",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "Clementinum Baroque Library IMG_1036_Original Copy-topaz-sharpen.jpg",
-        "description": "Baroque Library in the Clementinum, Prague"
+        "description": "Baroque Library in the Clementinum, Prague",
+        "albums": [
+            "Prague",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "IMG_1331.jpg",
-        "description": "Česky Krumlov, Czech Republic"
+        "description": "Česky Krumlov, Czech Republic",
+        "albums": [
+            "Czech Republic",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "IMG_1343.jpg",
-        "description": "Česky Krumlov, Czech Republic"
+        "description": "Česky Krumlov, Czech Republic",
+        "albums": [
+            "Czech Republic",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "IMG_1376.jpg",
-        "description": "Česky Krumlov, Czech Republic"
+        "description": "Česky Krumlov, Czech Republic",
+        "albums": [
+            "Czech Republic",
+            "2025 Central Europe"
+        ]
     },
     {
         "filename": "IMG_2353.jpg",
-        "description": "Budapest Parliament Building"
+        "description": "Budapest Parliament Building",
+        "albums": [
+            "Budapest",
+            "2025 Central Europe"
+        ]
     }
 ]

--- a/index.html
+++ b/index.html
@@ -26,12 +26,22 @@
         </div>
     </header>
 
-    <div class="search-container">
-        <input type="text" id="search-input" placeholder="Search photos..." aria-label="Search photos by description">
-    </div>
+    <div class="page-layout">
+        <aside class="sidebar" id="sidebar">
+            <h2>Albums</h2>
+            <ul class="album-list" id="album-list">
+                <!-- Populated by JS -->
+            </ul>
+        </aside>
+        <main class="main-content">
+            <div class="search-container">
+                <input type="text" id="search-input" placeholder="Search photos..." aria-label="Search photos by description">
+            </div>
 
-    <div class="gallery" id="gallery">
-        <!-- Images will be injected here -->
+            <div class="gallery" id="gallery">
+                <!-- Images will be injected here -->
+            </div>
+        </main>
     </div>
 
     <!-- Lightbox Modal -->


### PR DESCRIPTION
## Summary
- Add `albums` array field to images.json supporting multiple albums per photo
- Add sidebar with clickable album list that filters the gallery
- Combine album + search filtering for precise results
- Albums include: Prague, Budapest, Austria, Czech Republic, Northern Lights, 2025 Central Europe
- Mobile responsive: sidebar becomes horizontal scrollable pills at 900px

## Test plan
- [ ] Click album names in sidebar and verify gallery filters correctly
- [ ] Verify photos in multiple albums appear when either album is selected
- [ ] Verify "All Photos" shows everything
- [ ] Test search within a selected album
- [ ] Test on mobile - albums should display as horizontal pills
- [ ] Verify lightbox only cycles through filtered photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)